### PR TITLE
Schema update: Remove latest_version, add deprecated

### DIFF
--- a/src/primaschema/data/manifest_schema.json
+++ b/src/primaschema/data/manifest_schema.json
@@ -51,10 +51,6 @@
                             "type": "string"
                         }
                     },
-                    "latest_version": {
-                        "description": "The identifier (typically a number) of the latest released version of the scheme",
-                        "type": "string"
-                    },
                     "versions": {
                         "type": "array",
                         "uniqueItems": true,

--- a/src/primaschema/data/scheme_schema.json
+++ b/src/primaschema/data/scheme_schema.json
@@ -6,7 +6,7 @@
     "type": "object",
     "properties": {
         "schema_version": {
-            "description": "The version fo the schema that this scheme description complies with. Currently should be 1-0-0",
+            "description": "The version fo the schema that this scheme description complies with. Currently should be 1-0-1",
             "type": "string"
         },
         "name": {
@@ -100,6 +100,10 @@
         "derived_from": {
             "description": "Canonical name of the primer scheme from which this scheme was derived",
             "type": "string"
+        },
+        "deprecated": {
+            "description": "Whether the primer scheme is deprecated and should not longer be used",
+            "type": "boolean"
         },
         "notes": {
             "description": "Notes on the primer scheme",


### PR DESCRIPTION
This:

1. removes the "latest_version" key from the manifest schema
2. adds an optional "deprecated" key to the scheme info schemes
3. bumps the scheme info schema to version 1-0-1
4. adds a schema version to the manifest schema, with the recommendation that it is should be 1-0-0 for now