### PR TITLE
Add subcommand to print intervals spanned by primers

### DIFF
--- a/src/primaschema/cli.py
+++ b/src/primaschema/cli.py
@@ -130,6 +130,21 @@ def show_non_ref_alts(scheme_dir: Path):
     print(lib.show_non_ref_alts(scheme_dir=scheme_dir))
 
 
+def print_intervals(bed_path: Path):
+    """
+    Print intervals covered by primers in a BED file
+
+    :arg ref_path: Path of bed file
+    """
+    all_intervals = lib.compute_intervals(bed_path)
+    sorted_by_chrom = sorted(all_intervals.items())
+    for chrom, intervals in sorted_by_chrom:
+        sorted_interval_keys = sorted(intervals, key=lambda x: (x[0], x[1]))
+        for name in sorted_interval_keys:
+            interval = intervals[name]
+            print(f"{chrom}\t{interval[0]}\t{interval[1]}\t{name}")
+
+
 def main():
     defopt.run(
         {
@@ -144,6 +159,7 @@ def main():
             "6to7": six_to_seven,
             "7to6": seven_to_six,
             "show-non-ref-alts": show_non_ref_alts,
+            "intervals": print_intervals,
         },
         no_negated_flags=True,
         strict_kwonly=False,

--- a/src/primaschema/lib.py
+++ b/src/primaschema/lib.py
@@ -419,9 +419,13 @@ def compute_intervals(bed_path: Path) -> dict[str, dict[str, (int, int)]]:
     # find primer positions for all primers in the bed file and compute maximum
     # interval between primers of the same name
 
-    primer_name_re = re.compile(r'^(?P<name>.*)_(LEFT|RIGHT)(_alt[0-9]+)?$')
+    primer_name_re = re.compile(r'^(?P<name>.*)_(LEFT|RIGHT)(_.+)?$')
     all_intervals: dict[str, dict[str, (int, int)]] = {}
     for line in open(bed_path):
+        line_parts = line.strip().split('\t')
+        if len(line_parts) < 6:
+            # skip lines that don't have at least 6 fields
+            continue
         chrom, start, end, name, _, strand = line.strip().split("\t")[:6]
         if chrom not in all_intervals:
             all_intervals[chrom] = {}

--- a/src/primaschema/lib.py
+++ b/src/primaschema/lib.py
@@ -420,6 +420,7 @@ def compute_intervals(bed_path: Path) -> dict[str, dict[str, (int, int)]]:
     # interval between primers of the same name
 
     primer_name_re = re.compile(r'^(?P<name>.*)_(LEFT|RIGHT)(_.+)?$')
+    eden_primer_name_re = re.compile(r'^(?P<name>.*_[AB][0-9])(F|R)_\d+$')
     all_intervals: dict[str, dict[str, (int, int)]] = {}
     for line in open(bed_path):
         line_parts = line.strip().split('\t')
@@ -432,7 +433,10 @@ def compute_intervals(bed_path: Path) -> dict[str, dict[str, (int, int)]]:
         intervals = all_intervals[chrom]
         primer_match = primer_name_re.match(name)
         if not primer_match:
-            raise ValueError(f"Invalid primer name {name}")
+            # the Eden scheme has a unique primer name format
+            primer_match = eden_primer_name_re.match(name)
+            if not primer_name_re:
+                raise ValueError(f"Invalid primer name {name}")
         primer_name = primer_match.group("name")
         if strand == '+':
             start_pos = int(start)

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -141,3 +141,19 @@ def test_diff():
 MN908947.3       27784     27808 SARS-CoV-2_28_LEFT_27837T         2      + TTTGTGCTTTTTAGCCTTTCTGTT   bed2"""
         == run_cmd.stdout.strip()
     )
+
+
+def test_calculate_intervals():
+    all_intervals = lib.compute_intervals(data_dir / "primer-schemes/artic/v4.1/primer.bed")
+    assert 'MN908947.3' in all_intervals
+    intervals = all_intervals['MN908947.3']
+    assert 'SARS-CoV-2_99' in intervals
+    assert intervals['SARS-CoV-2_99'] == (29452, 29854)
+
+
+def test_print_intervals():
+    run_cmd = run("primaschema intervals primer-schemes/artic/v4.1/primer.bed")
+
+    assert (
+        """MN908947.3\t29452\t29854\tSARS-CoV-2_99\n""" in run_cmd.stdout
+    )


### PR DESCRIPTION
Given a `primer.bed` file like:

```
MN908947.3	25	50	SARS-CoV-2_1_LEFT	1	+	AACAAACCAACCAACTTTCGATCTC
MN908947.3	324	344	SARS-CoV-2_2_LEFT	2	+	TTTACAGGTTCGCGACGTGC
MN908947.3	408	431	SARS-CoV-2_1_RIGHT	1	-	CTTCTACTAAGCCACAAGTGCCA
MN908947.3	705	727	SARS-CoV-2_2_RIGHT	2	-	ATAAGGATCAGTGCCAAGCTCG
```

The new `intervals` subcommand prints:

```
MN908947.3      25      431     SARS-CoV-2_1
MN908947.3      324     727     SARS-CoV-2_2
```

Code is designed to work with PHA4GE-standard primer schemes and can deal with `alt` primers.