### PR TITLE
Seperate version field and new manifest format

### DIFF
--- a/schema/manifest_schema.json
+++ b/schema/manifest_schema.json
@@ -1,12 +1,12 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/pha4ge/primaschema/tree/main/schemas/mainfest_schema.json",
-    "title": "Primer Schemes Manifest",
-    "description": "A Manifest of Primer Schemes",
+    "title": "PHA4GE primer schemes manifest",
+    "description": "A manifest of tiled amplicon PCR primer scheme definitions",
     "type": "object",
     "properties": {
         "schema_version": {
-            "description": "The schema version of this manifest. Currently 2-0-0",
+            "description": "The schema version of this manifest. Currently 1-0-0",
             "type": "string"
         },
         "metadata": {
@@ -15,10 +15,6 @@
         },
         "repository": {
             "description": "A URI describing the location of the live, updatable version of the schema",
-            "type": "string"
-        },
-        "latest_doi": {
-            "description": "The Digital Object Identifier of the latest version of the manifest",
             "type": "string"
         },
         "license": {
@@ -59,10 +55,6 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "family": {
-                        "description": "The name of the scheme excluding the version",
-                        "type": "string"
-                    },
                     "aliases": {
                         "description": "Aliases for the scheme name",
                         "type": "array",
@@ -80,33 +72,10 @@
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "versions": {
-                        "type": "array",
-                        "uniqueItems": true,
-                        "minItems": 1,
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "version": {
-                                    "type": "string"
-                                },
-                                "repository": {
-                                    "description": "Link to the directory containing the scheme. This directory should follow the PHA4GE standard for schemes",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "version",
-                                "repository"
-                            ]
-                        }
                     }
                 },
                 "required": [
-                    "family",
-                    "organism",
-                    "versions"
+                    "organism"
                 ]
             }
         }
@@ -115,7 +84,6 @@
     "required": [
         "metadata",
         "repository",
-        "latest_doi",
         "license",
         "schemes"
     ]

--- a/schema/primer-scheme_schema.yml
+++ b/schema/primer-scheme_schema.yml
@@ -24,20 +24,18 @@ classes:
       - amplicon_size
       - version
       - organism
-      - organism_aliases
-      - display_name
-      - primer_scheme_status
+      - source_url
+      - definition_url
       - aliases
+      - license
+      - status
       - derived_from
       - developers
-      - vendors
-      - notes
       - citations
-      - license
-      - source_url
+      - notes
+      - vendors
       - primer_checksum
       - reference_checksum
-      - definition_url
 
   Vendor:
     class_uri: GENEPIO:0100674
@@ -70,9 +68,6 @@ slots:
     slot_uri: GENEPIO:0100682
     required: true
     description: The organism against which this primer scheme is targeted. Lowercase, e.g. sars-cov-2
-  organism_aliases:
-    description: "Aliases for the organism that this primer scheme targets"
-    multivalued: true
   aliases:
     slot_uri: GENEPIO:0100670
     description: Aliases for primer scheme name

--- a/schema/primer-scheme_schema.yml
+++ b/schema/primer-scheme_schema.yml
@@ -100,10 +100,10 @@ slots:
     multivalued: true
     inlined_as_list: true
     range: string
-  primer_scheme_status:
+  status:
     slot_uri: GENEPIO:0100681
     description: "The status of this primer scheme (e.g. published, deprecated)"
-    range: PrimerSchemeStatus
+    range: SchemeStatus
     ifabsent: string(PUBLISHED)
   license:
     description: "License under which the primer scheme is distributed"
@@ -133,7 +133,7 @@ slots:
     description: "A link to the home page of an organisation"
 
 enums:
-  PrimerSchemeStatus:
+  SchemeStatus:
     description: "Status of this amplicon primer scheme"
     permissible_values:
       PUBLISHED:

--- a/schema/primer-scheme_schema.yml
+++ b/schema/primer-scheme_schema.yml
@@ -1,6 +1,6 @@
 id: https://github.com/pha4ge/primer-schemes/schemas/primer-scheme
 name: primer-scheme
-description: Data model for tiling PCR primer scheme definitions
+description: Data model for tiling primer scheme definitions
 version: 1.0.0-alpha
 prefixes:
   linkml: https://w3id.org/linkml/
@@ -17,10 +17,11 @@ default_range: string
 classes:
   PrimerScheme:
     tree_root: true
-    description: "A description of an amplicon primer scheme"
+    description: "A tiled amplicon PCR primer scheme definition"
     slots:
       - schema_version
-      - name 
+      - name
+      - version
       - organism
       - organism_aliases
       - display_name
@@ -60,6 +61,9 @@ slots:
     identifier: true
     description: The canonical name of the primer scheme (lowercase)
     pattern: "^[\\da-z0-9_.-]+$"
+  version:
+    required: true
+    pattern: "^[\\da-z0-9_.-]+$"
   display_name:
     description: The human-friendly display name of the primer scheme
   organism:
@@ -82,7 +86,7 @@ slots:
   vendors:
     description: "Vendors where one can purchase the primers described in the amplicon scheme or a kit containing these primers"
     multivalued: true
-    inlined_as_list: true 
+    inlined_as_list: true
     range: Vendor
   amplicon_size:
     slot_uri: GENEPIO:0001449
@@ -115,7 +119,7 @@ slots:
   primer_checksum:
     slot_uri: GENEPIO:0100675
     description: "Checksum for the primer scheme BED file, in format checksum_type:checksum, where checksum_type is lowercase name of checksum generator e.g. primaschema"
-  reference_checksum: 
+  reference_checksum:
     description: "Checksum for the reference FASTA file, in format checksum_type:checksum, where checksum_type is lowercase name of checksum generator e.g. primaschema"
   derived_from:
     slot_uri: GENEPIO:0100671

--- a/schema/primer-scheme_schema.yml
+++ b/schema/primer-scheme_schema.yml
@@ -21,6 +21,7 @@ classes:
     slots:
       - schema_version
       - name
+      - amplicon_size
       - version
       - organism
       - organism_aliases
@@ -30,7 +31,6 @@ classes:
       - derived_from
       - developers
       - vendors
-      - amplicon_size
       - notes
       - citations
       - license
@@ -92,6 +92,7 @@ slots:
     slot_uri: GENEPIO:0001449
     description: "The length (in base pairs) of an amplicon in the primer scheme"
     range: integer
+    required: true
     minimum_value: 1
   definition_url:
     slot_uri: GENEPIO:0100683

--- a/src/primaschema/cli.py
+++ b/src/primaschema/cli.py
@@ -79,15 +79,14 @@ def build_recursive(
     lib.build_recursive(root_dir=root_dir, full=full, force=force, nested=nested)
 
 
-def build_manifest(root_dir: Path, schema_dir: Path = Path(), out_dir: Path = Path()):
+def build_manifest(root_dir: Path, out_dir: Path = Path()):
     """
     Build a complete manifest of schemes contained in the specified directory
 
     :arg root_dir: path in which to search for schemes
-    :arg schema_dir: path of schema directory
     :arg out_dir: path of directory in which to save manifest
     """
-    lib.build_manifest(root_dir=root_dir, schema_dir=schema_dir, out_dir=out_dir)
+    lib.build_manifest(root_dir=root_dir, out_dir=out_dir)
 
 
 def seven_to_six(bed_path: Path):

--- a/src/primaschema/lib.py
+++ b/src/primaschema/lib.py
@@ -396,6 +396,19 @@ def build_recursive(
 
 def build_manifest(root_dir: Path, out_dir: Path = Path()):
     """Build manifest of schemes inside the specified directory"""
+    manifest_field_subset = [
+        "name",
+        "amplicon_size",
+        "version",
+        "organism",
+        "source_url",
+        "definition_url",
+        "aliases",
+        "developers",
+        "citations",
+        "derived_from",
+        "status",
+    ]
     organisms = parse_yaml(organisms_path)
     manifest = {
         "schema_version": "1.0.0-alpha",
@@ -409,7 +422,8 @@ def build_manifest(root_dir: Path, out_dir: Path = Path()):
     for entry in scan(root_dir):
         if entry.is_file() and entry.name == "info.yml":
             scheme = parse_yaml(entry.path)
-            manifest["schemes"].append(scheme)
+            subset = {k: scheme[k] for k in manifest_field_subset if k in scheme}
+            manifest["schemes"].append(subset)
 
     manifest_file_name = "index.yml"
     with open(out_dir / manifest_file_name, "w") as fh:

--- a/src/primaschema/lib.py
+++ b/src/primaschema/lib.py
@@ -7,7 +7,6 @@ import os
 import re
 import shutil
 import sys
-from collections import defaultdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Literal
@@ -399,49 +398,18 @@ def build_manifest(root_dir: Path, out_dir: Path = Path()):
     """Build manifest of schemes inside the specified directory"""
     organisms = parse_yaml(organisms_path)
     manifest = {
-        "schema_version": "0.9.0",
-        "metadata": "The PHA4GE list of tiling amplicon primer schemes",
+        "schema_version": "1.0.0-alpha",
+        "metadata": "The manifest of PHA4GE tiled amplicon PCR primer scheme definitions",
         "repository": "https://github.com/pha4ge/primer-schemes",
-        "latest_doi": "",
         "license": "CC-BY-4.0",
         "organisms": organisms,
+        "schemes": [],
     }
 
-    names_schemes = {}
-    families_names = defaultdict(list)
     for entry in scan(root_dir):
         if entry.is_file() and entry.name == "info.yml":
             scheme = parse_yaml(entry.path)
-            name = scheme["name"]
-            names_schemes[name] = scheme
-            family, _, version = scheme["name"].partition("-")
-            families_names[family].append(name)
-
-    families_data = []
-    for family, names in sorted(families_names.items()):
-        family_data = {}
-        family_data["family"] = family
-        family_example_name = families_names[family][0]
-        family_data["organism"] = names_schemes[family_example_name]["organism"]
-        versions_data = []
-        definition_url = names_schemes[name].get("definition_url", "")
-        for name in sorted(names):
-            if names_schemes[name].get("display_name"):
-                display_name = names_schemes[name]["display_name"]
-            else:
-                display_name = name
-            versions_data.append(
-                {
-                    "name": name,
-                    "display_name": display_name,
-                    "version": name.partition("-")[2],
-                    "repository": definition_url,
-                }
-            )
-            logger.info(f"Reading {name}")
-        family_data["versions"] = versions_data
-        families_data.append(family_data)
-    manifest["schemes"] = families_data
+            manifest["schemes"].append(scheme)
 
     manifest_file_name = "index.yml"
     with open(out_dir / manifest_file_name, "w") as fh:

--- a/test/data/primer-schemes/schemes/sars-cov-2/artic/v4.1/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/artic/v4.1/info.yml
@@ -1,5 +1,6 @@
 schema_version: 1.0.0-alpha
 name: artic
+amplicon_size: 400
 version: v4.1
 organism: sars-cov-2
 aliases:
@@ -11,7 +12,6 @@ vendors:
   kit_name: '10011442'
 - organisation_name: Eurofins
   home_page: https://eurofinsgenomics.com
-amplicon_size: 400
 definition_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/artic/v4.1
 source_url: https://github.com/quick-lab/primerschemes/tree/main/primerschemes/artic-sars-cov-2/400/v4.1.0
 citations:

--- a/test/data/primer-schemes/schemes/sars-cov-2/artic/v4.1/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/artic/v4.1/info.yml
@@ -1,5 +1,6 @@
 schema_version: 1.0.0-alpha
-name: artic-v4.1
+name: artic
+version: v4.1
 organism: sars-cov-2
 aliases:
 - ARTIC/V4.1

--- a/test/data/primer-schemes/schemes/sars-cov-2/eden/v1/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/eden/v1/info.yml
@@ -1,5 +1,6 @@
 schema_version: 1.0.0-alpha
-name: eden-v1
+name: eden
+version: v1
 organism: sars-cov-2
 aliases:
 - sydney

--- a/test/data/primer-schemes/schemes/sars-cov-2/eden/v1/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/eden/v1/info.yml
@@ -1,5 +1,6 @@
 schema_version: 1.0.0-alpha
 name: eden
+amplicon_size: 2500
 version: v1
 organism: sars-cov-2
 aliases:
@@ -7,7 +8,6 @@ aliases:
 developers:
 - John-Sebastian Eden
 - Eby Sim
-amplicon_size: 2500
 definition_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/eden/v1
 citations:
 - https://www.protocols.io/view/sars-cov-2-genome-sequencing-using-long-pooled-amp-kxygxeob4v8j/v1

--- a/test/data/primer-schemes/schemes/sars-cov-2/midnight/v1/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/midnight/v1/info.yml
@@ -1,5 +1,6 @@
 schema_version: 1.0.0-alpha
 name: midnight
+amplicon_size: 1200
 version: v1
 organism: sars-cov-2
 aliases:
@@ -13,7 +14,6 @@ vendors:
 - organisation_name: Oxford Nanopore Technologies
   kit_name: MRT001.10
 - organisation_name: Integrated DNA Technologies
-amplicon_size: 1200
 definition_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/midnight/v1
 citations:
 - https://dx.doi.org/10.17504/protocols.io.bwyppfvn

--- a/test/data/primer-schemes/schemes/sars-cov-2/midnight/v1/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/midnight/v1/info.yml
@@ -1,5 +1,6 @@
 schema_version: 1.0.0-alpha
-name: midnight-v1
+name: midnight
+version: v1
 organism: sars-cov-2
 aliases:
 - midnight-ont-v1

--- a/test/data/primer-schemes/schemes/sars-cov-2/midnight/v1/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/midnight/v1/info.yml
@@ -18,6 +18,6 @@ definition_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/mi
 citations:
 - https://dx.doi.org/10.17504/protocols.io.bwyppfvn
 license: CC-BY-4.0
-primer_scheme_status: DEPRECATED
+status: DEPRECATED
 primer_checksum: primaschema:e1303ce0367cc245
 reference_checksum: primaschema:7d5621cd3b3e498d

--- a/test/data/primer-schemes/schemes/sars-cov-2/midnight/v2/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/midnight/v2/info.yml
@@ -1,5 +1,6 @@
 schema_version: 1.0.0-alpha
-name: midnight-v2
+name: midnight
+version: v2
 organism: sars-cov-2
 aliases:
 - midnight-ont-v2

--- a/test/data/primer-schemes/schemes/sars-cov-2/midnight/v2/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/midnight/v2/info.yml
@@ -1,5 +1,6 @@
 schema_version: 1.0.0-alpha
 name: midnight
+amplicon_size: 1200
 version: v2
 organism: sars-cov-2
 aliases:
@@ -13,7 +14,6 @@ developers:
 vendors:
 - organisation_name: Oxford Nanopore Technologies
   kit_name: MRT001.20
-amplicon_size: 1200
 definition_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/midnight/v2
 citations:
 - https://dx.doi.org/10.17504/protocols.io.bwyppfvn

--- a/test/data/primer-schemes/schemes/sars-cov-2/midnight/v2/info.yml
+++ b/test/data/primer-schemes/schemes/sars-cov-2/midnight/v2/info.yml
@@ -22,6 +22,6 @@ notes:
 - https://twitter.com/freed_nikki/status/1464477522448433156
 - Not considered a new version by Freed et al. and IDT despite additional primer
 license: CC-BY-4.0
-primer_scheme_status: DEPRECATED
+status: DEPRECATED
 primer_checksum: primaschema:8f733a1f180c435a
 reference_checksum: primaschema:7d5621cd3b3e498d


### PR DESCRIPTION
- Split version into its own field and update schema to pass tests
- Flatten manifest to use a subset of info.yaml fields. A limitation is that this is built from parsing YAML directly rather than being schema-backed and therefore including optional fields with default values.
- Fix bug in build-manifest CLI
- Make amplicon_size required since we might want to accommodate identical scheme names and versions with different amplicon lengths.