### PR TITLE
Simplify build-manifest

### DIFF
--- a/schema/header.yml
+++ b/schema/header.yml
@@ -1,3 +1,8 @@
+schema_version: "1.0.0-alpha"
+metadata: The manifest of PHA4GE tiled amplicon PCR primer scheme definitions
+repository: https://github.com/pha4ge/primer-schemes
+license: CC-BY-4.0
+organisms:
 - organism: sars-cov-2
   display_name: SARS-CoV-2
   aliases:

--- a/src/primaschema/__init__.py
+++ b/src/primaschema/__init__.py
@@ -2,17 +2,18 @@
 
 import logging
 import logging.config
+import os
 
 from pathlib import Path
 
 
 __version__ = "0.2.0"
 
-pkg_dir = Path(__file__).resolve().parent.parent.parent
+pkg_dir = os.getenv('PRIMER_SCHEMES', Path(__file__).resolve().parent.parent.parent)
 schema_dir = pkg_dir / "schema"
 primer_scheme_schema_path = schema_dir / "primer-scheme_schema.yml"
 manifest_schema_path = schema_dir / "manifest_schema.json"
-organisms_path = schema_dir / "organisms.yml"
+header_path = schema_dir / "header.yml"
 # print(f"{pkg_dir=} {schema_dir=} {schema_path=}")
 
 logging_config = {

--- a/src/primaschema/__init__.py
+++ b/src/primaschema/__init__.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 __version__ = "0.2.0"
 
-pkg_dir = os.getenv('PRIMER_SCHEMES', Path(__file__).resolve().parent.parent.parent)
-schema_dir = pkg_dir / "schema"
+pkg_dir = Path(__file__).resolve().parent.parent.parent
+schema_dir = os.environ.get('PRIMER_SCHEMA_DIR', pkg_dir / "schema")
 primer_scheme_schema_path = schema_dir / "primer-scheme_schema.yml"
 manifest_schema_path = schema_dir / "manifest_schema.json"
 header_path = schema_dir / "header.yml"

--- a/src/primaschema/lib.py
+++ b/src/primaschema/lib.py
@@ -405,6 +405,10 @@ def build_manifest(root_dir: Path, out_dir: Path = Path()):
     
     manifest = parse_yaml(header_path)
 
+    manifest_field_exclude = [
+        "schema_version",
+    ]
+
     scheme_path = root_dir / "schemes"
     if not scheme_path.exists():
         scheme_path = root_dir
@@ -413,6 +417,9 @@ def build_manifest(root_dir: Path, out_dir: Path = Path()):
     organism_set = set([o["organism"] for o in manifest["organisms"]])
     for scheme_info_path in scheme_path.glob("**/info.yml"):
         scheme = parse_yaml(scheme_info_path)
+        for field in manifest_field_exclude:
+            if field in scheme:
+                del scheme[field]
         if scheme["organism"] not in organism_set:
             print(f"Warning: skipping scheme {scheme['name']} with unknown organism {scheme['organism']}", file=sys.stderr)
             continue


### PR DESCRIPTION
* Simply flatten all the `info.yml` from the scheme directories into a list of schemes
* Read the header from a file and do away with `organisms,yml`
* Allow the schema directory to be specified using `PRIMER_SCHEMA_DIR` environment variable